### PR TITLE
Add future package providing a Future API for R

### DIFF
--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -4,7 +4,7 @@
    <name>HighPerformanceComputing</name>
    <topic>High-Performance and Parallel Computing with R</topic>
    <maintainer email="Dirk.Eddelbuettel@R-project.org">Dirk Eddelbuettel</maintainer>
-   <version>2015-07-01</version>
+   <version>2015-07-14</version>
 
   <info>
     <p>
@@ -122,6 +122,17 @@
 	above), <pkg>doMPI</pkg> (using <pkg>Rmpi</pkg>) packages and
 	<pkg>doRedis</pkg> (using <pkg>rredis</pkg>) packages.
       </li>
+      <li>The <pkg>future</pkg> package defines a Future API for R. 
+        A future is an abstraction for a value that may be available at
+        some point in the future. How and when futures are resolved varies
+        with implementation. The package implements "lazy" and "eager"
+        (synchronous) futures and a "multicore" (asynchronous) future, but
+        other types can/will be implemented by other packages. Futures can
+        be controlled explicitly via future-value calls or implicitly via
+        delayed assignment operators / promises.  Iteration over elements 
+        in a collection is supported and global variables are automatically
+        taken care of.
+   </li>
       <li>The <pkg>bigrf</pkg> package provides a Random Forests
         implementation with support for parellel execution and large
         memory. 

--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -122,16 +122,11 @@
 	above), <pkg>doMPI</pkg> (using <pkg>Rmpi</pkg>) packages and
 	<pkg>doRedis</pkg> (using <pkg>rredis</pkg>) packages.
       </li>
-      <li>The <pkg>future</pkg> package defines a Future API for R. 
-        A future is an abstraction for a value that may be available at
-        some point in the future. How and when futures are resolved varies
-        with implementation. The package implements "lazy" and "eager"
-        (synchronous) futures and a "multicore" (asynchronous) future, but
-        other types can/will be implemented by other packages. Futures can
-        be controlled explicitly via future-value calls or implicitly via
-        delayed assignment operators / promises.  Iteration over elements 
-        in a collection is supported and global variables are automatically
-        taken care of.
+      <li>The <pkg>future</pkg> package allows for synchroneous (sequential)
+        and asynchronous (parallel) evaluations via abstraction of futures,
+        either via function calls or implicitly via promises. Global variables
+        are automatically identified. Iteration over elements in a collection
+        is supported.
    </li>
       <li>The <pkg>bigrf</pkg> package provides a Random Forests
         implementation with support for parellel execution and large


### PR DESCRIPTION
Hi.

My [future](http://cran.r-project.org/package=future) package is ready for some more CPU mileage.  Please add it to http://cran.r-project.org/web/views/HighPerformanceComputing.html.  Feel free to modify my proposed paragraph.

Cheers

Henrik
