### PR TITLE
Update the description of drake

### DIFF
--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -194,10 +194,11 @@
       <li>
         The <pkg>drake</pkg> package is an R-focused 
         <a href="https://github.com/pditommaso/awesome-pipeline">pipeline toolkit</a> similar to
-        <a href="https://www.gnu.org/software/make">Make</a>. Implicit parallelism is available through the
+        <a href="https://www.gnu.org/software/make">Make</a>. Parallel computing relies on the
         <code>parallel</code>, <code>future</code>, <code>batchtools</code>,
         and <code>future.batchtools</code> packages, as well as 
-        <a href="https://www.gnu.org/software/make">Makefiles</a>.
+        <a href="https://www.gnu.org/software/make">Makefiles</a>. Drake uses code analysis
+        to configure the user's workflow and make the parallelism implicit.
       </li>
     </ul>
 

--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -193,13 +193,14 @@
       </li>
       <li>
         The <pkg>drake</pkg> package is an R-focused reproducible build system.
-        Similarly to <a href="https://www.gnu.org/software/make">Make</a>, it 
-        arranges the intermediate steps of a workflow and executes them in parallelizable stages. 
-        With three alternative backends
-        (powered by <code>parallel::mclapply()</code>, <code>parallel::parLapply()</code>,
-        and <a href="https://www.gnu.org/software/make">Makefiles</a>, respectivly)
-        drake supports implicit parallelism both for low-overhead single-node 
-        applications and for true distributed computing workloads.
+        Similarly to <a href="https://www.gnu.org/software/make">Make</a>, drake 
+        arranges the intermediate steps of a workflow and executes them in parallelizable
+        stages. Drake supports an full arsenal of parallel backends
+        ranging from local multicore computing to serious distributed computing
+        on clusters and formal job schedulers. Backends draw from the
+        <code>parallel</code>, <code>future</code>, <code>batchtools</code>,
+        and <code>future.batchtools</code> packages, and
+        <a href="https://www.gnu.org/software/make">Makefile</a>.
       </li>
     </ul>
 

--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -195,12 +195,12 @@
         The <pkg>drake</pkg> package is an R-focused reproducible build system.
         Similarly to <a href="https://www.gnu.org/software/make">Make</a>, drake 
         arranges the intermediate steps of a workflow and executes them in parallelizable
-        stages. Drake supports an full arsenal of parallel backends
+        stages. Drake supports a full arsenal of parallel backends,
         ranging from local multicore computing to serious distributed computing
-        on clusters and formal job schedulers. Backends draw from the
+        on clusters. Backends draw from the
         <code>parallel</code>, <code>future</code>, <code>batchtools</code>,
-        and <code>future.batchtools</code> packages, and
-        <a href="https://www.gnu.org/software/make">Makefile</a>.
+        and <code>future.batchtools</code> packages, as well as 
+        <a href="https://www.gnu.org/software/make">Makefiles</a>.
       </li>
     </ul>
 

--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -192,12 +192,18 @@
         The <pkg>Rhpc</pkg> permits <code>*apply()</code> style dispatch via MPI.
       </li>
       <li>
-        The <pkg>drake</pkg> package is an R-focused reproducible build system.
+        The <pkg>drake</pkg> package is an R-focused 
+        <a href="https://github.com/pditommaso/awesome-pipeline">pipeline toolkit</a>.
         Similarly to <a href="https://www.gnu.org/software/make">Make</a>, drake 
         arranges the intermediate steps of a workflow and executes them in parallelizable
-        stages. Drake supports a full arsenal of parallel backends,
-        ranging from local multicore computing to serious distributed computing
-        on clusters. Backends draw from the
+        stages, skipping work that is already up to date.
+        Drake supports a vast arsenal of parallel backends,
+        ranging from local multicore processing to serious distributed computing
+        on clusters that use 
+        <a href="https://slurm.schedmd.com/">SLURM</a>,
+        <a href="http://www.adaptivecomputing.com/products/open-source/torque/">TORQUE</a>,
+        the <a href="http://www.univa.com/products/">Univa Grid Engine</a>,
+        and other formal job schedulers. Backends draw from the
         <code>parallel</code>, <code>future</code>, <code>batchtools</code>,
         and <code>future.batchtools</code> packages, as well as 
         <a href="https://www.gnu.org/software/make">Makefiles</a>.

--- a/HighPerformanceComputing.ctv
+++ b/HighPerformanceComputing.ctv
@@ -193,17 +193,8 @@
       </li>
       <li>
         The <pkg>drake</pkg> package is an R-focused 
-        <a href="https://github.com/pditommaso/awesome-pipeline">pipeline toolkit</a>.
-        Similarly to <a href="https://www.gnu.org/software/make">Make</a>, drake 
-        arranges the intermediate steps of a workflow and executes them in parallelizable
-        stages, skipping work that is already up to date.
-        Drake supports a vast arsenal of parallel backends,
-        ranging from local multicore processing to serious distributed computing
-        on clusters that use 
-        <a href="https://slurm.schedmd.com/">SLURM</a>,
-        <a href="http://www.adaptivecomputing.com/products/open-source/torque/">TORQUE</a>,
-        the <a href="http://www.univa.com/products/">Univa Grid Engine</a>,
-        and other formal job schedulers. Backends draw from the
+        <a href="https://github.com/pditommaso/awesome-pipeline">pipeline toolkit</a> similar to
+        <a href="https://www.gnu.org/software/make">Make</a>. Implicit parallelism is available through the
         <code>parallel</code>, <code>future</code>, <code>batchtools</code>,
         and <code>future.batchtools</code> packages, as well as 
         <a href="https://www.gnu.org/software/make">Makefiles</a>.


### PR DESCRIPTION
Effective in the CRAN release of [version 4.4.0](https://github.com/wlandau-lilly/drake/releases/tag/v4.4.0), the high-performance computing backends in [drake](https://github.com/wlandau-lilly/drake) include `future_lapply()`, which connects to `batchtools` via `future.batchtools`. Now, it is straightforward to configure [drake](https://github.com/wlandau-lilly/drake) for formal resource managers such as SLURM, TORQUE, and the Univa Grid Engine.