### PR TITLE
Add {SLmetrics} to the CTV

### DIFF
--- a/HighPerformanceComputing.md
+++ b/HighPerformanceComputing.md
@@ -248,6 +248,7 @@ functions are planned for later R releases.
     models in parallel (for the algorithm `"saem"`).
 -   The `r pkg("parabar")` package implements a progress bar for parallel applications; the 
     `r pkg("doParabar")` package builds on this with a `foreach`  parallel adapter for `parabar` backends.
+-   The `r pkg("SLmetrics")` package is a C++17/Armadillo implementation of 40+ classification, regression, clustering and time‑series metrics; vectorised pointer‑level loops and optional OpenMP parallelism deliver fast, low‑memory scoring of very large prediction arrays.
 
 ### Parallel computing: GPUs
 


### PR DESCRIPTION
Hi @eddelbuettel ,

Below is a simple showcase of {SLmetrics} vs {base} with `na.rm = FALSE`:

``` r
actual <- rnorm(n = 1e8)
predicted <- actual +  rnorm(n = 1e8)

bench::mark(
  `{SLmetrics}` = SLmetrics::rmse(actual,predicted),
  `{base}` = sqrt(mean(
    (actual - predicted)^2,
    na.rm = FALSE
  ))
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 {SLmetrics}   56.1ms   57.1ms     17.4     5.96MB     0   
#> 2 {base}       451.1ms  451.8ms      2.21  762.96MB     2.21
```

<sup>Created on 2025-04-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I believe that this difference justifies adding {SLmetrics} on the list! 

Best,

Serkan